### PR TITLE
Small setup.py fixes

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,4 +43,6 @@ setup(name='deepblast',
       ],
       scripts=glob('scripts/*'),
       classifiers=classifiers,
-      package_data={})
+      package_data={
+          'deepblast': ['pretrained_models/lstm2x.pt'],
+      })

--- a/setup.py
+++ b/setup.py
@@ -39,6 +39,7 @@ setup(name='deepblast',
           'pytorch-lightning>=0.8.1',
           'matplotlib',
           'pillow',
+          'biopython>=1.78,<2.0'
       ],
       scripts=glob('scripts/*'),
       classifiers=classifiers,


### PR DESCRIPTION
This pull request adds the missing biopython and `deepblast/pretrained_models/lstm2x.pt` to setup.py. The `lstm2x.pt` part is required because without it language_model.py doesn't find the model when installed through pip instead of checking out the repository.