### PR TITLE
fix typo when indexing into gap scores in forward pass

### DIFF
--- a/deepblast/nw.py
+++ b/deepblast/nw.py
@@ -55,7 +55,7 @@ def _forward_pass_numba(theta, A):
         for j in range(1, M + 1):
             maxargs[x] = A[i - 1, j - 1] + V[i - 1, j]  # x
             maxargs[m] = V[i - 1, j - 1]  # m
-            maxargs[y] = A[i - j, 1 - 1] + V[i, j - 1]  # y
+            maxargs[y] = A[i - 1, j - 1] + V[i, j - 1]  # y
             v, Q[i, j] = _soft_max_numba(maxargs)
             V[i, j] = theta[i - 1, j - 1] + v
     Vt = V[N, M]

--- a/deepblast/sw.py
+++ b/deepblast/sw.py
@@ -55,7 +55,7 @@ def _forward_pass_numba(theta, A):
         for j in range(2, M + 1):
             maxargs[x] = A[i - 1, j - 1] + V[i - 1, j]  # x
             maxargs[m] = V[i - 1, j - 1]  # m
-            maxargs[y] = A[i - j, 1 - 1] + V[i, j - 1]  # y
+            maxargs[y] = A[i - 1, j - 1] + V[i, j - 1]  # y
             v, Q[i, j] = _soft_max_numba(maxargs)
             V[i, j] = theta[i - 1, j - 1] + v
     Vt = V[N, M]


### PR DESCRIPTION
Hi DeepBLAST team,

while trying out the [Aligning proteins example](https://github.com/flatironinstitute/deepblast/wiki/Aligning-proteins) from your Wiki page, I noticed somewhat undefined behaviour when trying to align two specific sequences when loading the DeepBLAST model on the CPU:
```
import torch, os
from deepblast.utils import load_model

os.system("wget https://users.flatironinstitute.org/jmorton/public_www/deepblast-public-data/checkpoints/deepblast-pt-l8.ckpt")

model = load_model("deepblast-pt-l8.ckpt",  device="cpu")

seq_1 = "GGREGVLKKLRAVENELHYNKSLLEEVKD"
seq_2 = "QTNINSLAVRGKDCTVVISQKKVPDKLLDPTTVSYIFCISRTIGMVVNGPIPDARNAALRAKAEAAEFRYKYG"

pred_alignment = model.align(seq_1, seq_2)
print(pred_alignment)
```

Running this example sometimes succeeds, but often prints a different alignment string for every re-run, which it should'nt. The calculated alignments also differ from the alignment that gets calculated when running the model on the GPU with the same input sequences.
Other times the program crashes with errors like `RuntimeError: Function 'NeedlemanWunschFunctionBackward' returned nan values in its 0th output.` or `IndexError: index -30 is out of bounds for dimension 0 with size 29`.

I fixed these errors for myself by adjusting the indices that are used in the `_forward_pass_numba` function in [nw.py](https://github.com/flatironinstitute/deepblast/blob/master/deepblast/nw.py) to access the gap scores/penalties. This also looks like it is maybe just a typo.