### PR TITLE
sw: updates regression tests to match bugfix from 81ac6e3

### DIFF
--- a/deepblast/tests/test_sw.py
+++ b/deepblast/tests/test_sw.py
@@ -48,8 +48,7 @@ class TestSmithWatermanDecoder(unittest.TestCase):
         v = smithwaterman(theta, A)
         v.backward()
         decoded = smithwaterman.traceback(theta.grad.squeeze())
-        states = [(0, 0, 0), (1, 0, 0), (2, 0, 1), (3, 1, 1), (4, 2, 2),
-                  (4, 3, 1)]
+        states = [(-1, 0, 1), (0, 1, 0), (1, 1, 0), (2, 1, 0), (3, 1, 1), (4, 2, 2), (4, 3, 1)]
         self.assertListEqual(states, decoded)
 
     def test_grad_smithwaterman_function(self):

--- a/deepblast/tests/test_sw_cuda.py
+++ b/deepblast/tests/test_sw_cuda.py
@@ -66,7 +66,7 @@ class TestSmithWatermanDecoder(unittest.TestCase):
         v.backward()
         decoded = needle.traceback(theta.grad.squeeze())
         decoded = [(x[0], x[1]) for x in decoded]
-        states = [(0, 0), (1, 0), (2, 0), (3, 1), (4, 2), (4, 3)]
+        states = [(0, 0), (0, 1), (1, 1), (2, 1), (3, 1), (4, 2), (4, 3)]
         self.assertListEqual(states, decoded)
 
     @unittest.skipUnless(torch.cuda.is_available(), 'No GPU was detected')


### PR DESCRIPTION
closes #146

Would be nice to have known result rather than regression here. This is almost `if true == true`. @mortonjt at least for the 'None' operator, have you compared this to other implementations? I understand that `softmax` might screw with things in some cases.