### PR TITLE
migrated to newer version of lightning

### DIFF
--- a/deepblast/dataset/utils.py
+++ b/deepblast/dataset/utils.py
@@ -406,7 +406,7 @@ def gap_mask(states: str, sparse=False):
     if sparse:
         return mat
     else:
-        return mat.toarray().astype(np.bool)
+        return mat.toarray().astype(bool)
 
 
 def window(seq, n=2):


### PR DESCRIPTION
Using the official migration guide available at [this PR](https://github.com/Lightning-AI/pytorch-lightning/pull/16520). The `validation_epoch_end` function was replaced with `on_validation_epoch_end`, so I updated the `DeepBLAST` class to ensure compatibility with `pytorch-lightening` and fixed the following error: 

```
NotImplementedError: Support for `validation_epoch_end` has been removed in v2.0.0. 
`DeepBLAST` implements this method. You can use the `on_validation_epoch_end` hook instead. 
To access outputs, save them in-memory as instance attributes.
```

Additionally, I resolved a deprecation warning caused by the use of `np.bool` by switching to `bool`